### PR TITLE
refactor: rename package remote to package etcd

### DIFF
--- a/c.go
+++ b/c.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/DoNewsCode/core/codec/yaml"
 	"github.com/DoNewsCode/core/config"
-	"github.com/DoNewsCode/core/config/remote"
 	"github.com/DoNewsCode/core/config/watcher"
 	"github.com/DoNewsCode/core/container"
 	"github.com/DoNewsCode/core/contract"
@@ -24,7 +23,6 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/knadh/koanf/providers/confmap"
 	"github.com/knadh/koanf/providers/file"
-	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 // C stands for the core of the application. It contains service definitions and
@@ -91,13 +89,6 @@ type CoreOption func(*coreValues)
 func WithYamlFile(path string) (CoreOption, CoreOption) {
 	return WithConfigStack(file.Provider(path), config.CodecParser{Codec: yaml.Codec{}}),
 		WithConfigWatcher(watcher.File{Path: path})
-}
-
-// WithRemoteYamlFile is a two-in-one coreOption. It uses the remote key on etcd as the
-// source of configuration, and watches the change of that key for hot reloading.
-func WithRemoteYamlFile(key string, cfg clientv3.Config) (CoreOption, CoreOption) {
-	r := remote.Provider(key, &cfg)
-	return WithConfigStack(r, config.CodecParser{Codec: yaml.Codec{}}), WithConfigWatcher(r)
 }
 
 // WithInline is a CoreOption that creates a inline config in the configuration stack.

--- a/config/remote/etcd/etcd.go
+++ b/config/remote/etcd/etcd.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-
+	"github.com/DoNewsCode/core"
+	"github.com/DoNewsCode/core/config"
+	"github.com/DoNewsCode/core/contract"
 	"go.etcd.io/etcd/client/v3"
 )
 
@@ -17,11 +19,18 @@ type ETCD struct {
 }
 
 // Provider create a *ETCD
-func Provider(key string, clientConfig *clientv3.Config) *ETCD {
+func Provider(clientConfig *clientv3.Config, key string) *ETCD {
 	return &ETCD{
 		key:          key,
 		clientConfig: clientConfig,
 	}
+}
+
+// WithKey is a two-in-one coreOption. It uses the remote key on etcd as the
+// source of configuration, and watches the change of that key for hot reloading.
+func WithKey(cfg *clientv3.Config, key string, codec contract.Codec) (core.CoreOption, core.CoreOption) {
+	r := Provider(cfg, key)
+	return core.WithConfigStack(r, config.CodecParser{Codec: codec}), core.WithConfigWatcher(r)
 }
 
 // ReadBytes reads the contents of a key from etcd and returns the bytes.

--- a/config/remote/etcd/etcd.go
+++ b/config/remote/etcd/etcd.go
@@ -15,11 +15,11 @@ import (
 // The remote client uses etcd.
 type ETCD struct {
 	key          string
-	clientConfig *clientv3.Config
+	clientConfig clientv3.Config
 }
 
 // Provider create a *ETCD
-func Provider(clientConfig *clientv3.Config, key string) *ETCD {
+func Provider(clientConfig clientv3.Config, key string) *ETCD {
 	return &ETCD{
 		key:          key,
 		clientConfig: clientConfig,
@@ -28,14 +28,14 @@ func Provider(clientConfig *clientv3.Config, key string) *ETCD {
 
 // WithKey is a two-in-one coreOption. It uses the remote key on etcd as the
 // source of configuration, and watches the change of that key for hot reloading.
-func WithKey(cfg *clientv3.Config, key string, codec contract.Codec) (core.CoreOption, core.CoreOption) {
+func WithKey(cfg clientv3.Config, key string, codec contract.Codec) (core.CoreOption, core.CoreOption) {
 	r := Provider(cfg, key)
 	return core.WithConfigStack(r, config.CodecParser{Codec: codec}), core.WithConfigWatcher(r)
 }
 
 // ReadBytes reads the contents of a key from etcd and returns the bytes.
 func (r *ETCD) ReadBytes() ([]byte, error) {
-	client, err := clientv3.New(*r.clientConfig)
+	client, err := clientv3.New(r.clientConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +62,7 @@ func (r *ETCD) Read() (map[string]interface{}, error) {
 // it should reload the whole config stack. For example, if the flag or env takes precedence over the config
 // key, they should remain to be so after the key changes.
 func (r *ETCD) Watch(ctx context.Context, reload func() error) error {
-	client, err := clientv3.New(*r.clientConfig)
+	client, err := clientv3.New(r.clientConfig)
 	if err != nil {
 		return err
 	}

--- a/config/remote/etcd/etcd.go
+++ b/config/remote/etcd/etcd.go
@@ -1,4 +1,5 @@
-package remote
+// Package etcd allows the core package to bootstrap its configuration from an etcd server.
+package etcd
 
 import (
 	"context"
@@ -8,23 +9,23 @@ import (
 	"go.etcd.io/etcd/client/v3"
 )
 
-// Remote is a core.ConfProvider and contract.ConfigWatcher implementation to read and watch remote config key.
+// ETCD is a core.ConfProvider and contract.ConfigWatcher implementation to read and watch remote config key.
 // The remote client uses etcd.
-type Remote struct {
-	key         string
+type ETCD struct {
+	key          string
 	clientConfig *clientv3.Config
 }
 
-// Provider create a *Remote
-func Provider(key string, clientConfig *clientv3.Config) *Remote {
-	return &Remote{
-		key:         key,
+// Provider create a *ETCD
+func Provider(key string, clientConfig *clientv3.Config) *ETCD {
+	return &ETCD{
+		key:          key,
 		clientConfig: clientConfig,
 	}
 }
 
 // ReadBytes reads the contents of a key from etcd and returns the bytes.
-func (r *Remote) ReadBytes() ([]byte, error) {
+func (r *ETCD) ReadBytes() ([]byte, error) {
 	client, err := clientv3.New(*r.clientConfig)
 	if err != nil {
 		return nil, err
@@ -43,7 +44,7 @@ func (r *Remote) ReadBytes() ([]byte, error) {
 }
 
 // Read is not supported by the remote provider.
-func (r *Remote) Read() (map[string]interface{}, error) {
+func (r *ETCD) Read() (map[string]interface{}, error) {
 	return nil, errors.New("remote provider does not support this method")
 }
 
@@ -51,7 +52,7 @@ func (r *Remote) Read() (map[string]interface{}, error) {
 // will be called. note the reload function should not just load the changes made within this key, but rather
 // it should reload the whole config stack. For example, if the flag or env takes precedence over the config
 // key, they should remain to be so after the key changes.
-func (r *Remote) Watch(ctx context.Context, reload func() error) error {
+func (r *ETCD) Watch(ctx context.Context, reload func() error) error {
 	client, err := clientv3.New(*r.clientConfig)
 	if err != nil {
 		return err
@@ -74,4 +75,3 @@ func (r *Remote) Watch(ctx context.Context, reload func() error) error {
 		}
 	}
 }
-

--- a/config/remote/etcd/etcd_test.go
+++ b/config/remote/etcd/etcd_test.go
@@ -133,7 +133,10 @@ func put(r *ETCD, val string) error {
 	}
 	defer client.Close()
 
-	_, err = client.Put(context.Background(), r.key, val)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	_, err = client.Put(ctx, r.key, val)
 	if err != nil {
 		return err
 	}

--- a/config/remote/etcd/etcd_test.go
+++ b/config/remote/etcd/etcd_test.go
@@ -19,12 +19,12 @@ func TestRemote(t *testing.T) {
 		return
 	}
 	addrs := strings.Split(os.Getenv("ETCD_ADDR"), ",")
-	cfg := &clientv3.Config{
+	cfg := clientv3.Config{
 		Endpoints:   addrs,
 		DialTimeout: 2 * time.Second,
 	}
 
-	r := Provider("config.yaml", cfg)
+	r := Provider(cfg, "config.yaml")
 
 	var testVal = "name: app"
 	// PREPARE TEST DATA
@@ -71,12 +71,12 @@ func TestError(t *testing.T) {
 		err error
 	)
 
-	cfg := &clientv3.Config{
+	cfg := clientv3.Config{
 		Endpoints:   []string{},
 		DialTimeout: 2 * time.Second,
 	}
 
-	r = Provider("config.yaml", cfg)
+	r = Provider(cfg, "config.yaml")
 	err = put(r, "test")
 	assert.Error(t, err)
 
@@ -88,15 +88,15 @@ func TestError(t *testing.T) {
 	})
 	assert.Error(t, err)
 
-	cfg = &clientv3.Config{
+	cfg = clientv3.Config{
 		Endpoints:   addrs,
 		DialTimeout: 2 * time.Second,
 	}
-	r = Provider("config-test1", cfg)
+	r = Provider(cfg, "config-test1")
 	_, err = r.ReadBytes()
 	assert.Error(t, err)
 
-	r = Provider("config-test2", cfg)
+	r = Provider(cfg, "config-test2")
 
 	// Confirm that the two coroutines are finished
 	g := sync.WaitGroup{}
@@ -127,7 +127,7 @@ func TestError(t *testing.T) {
 }
 
 func put(r *ETCD, val string) error {
-	client, err := clientv3.New(*r.clientConfig)
+	client, err := clientv3.New(r.clientConfig)
 	if err != nil {
 		return err
 	}

--- a/config/remote/etcd/etcd_test.go
+++ b/config/remote/etcd/etcd_test.go
@@ -1,4 +1,4 @@
-package remote
+package etcd
 
 import (
 	"context"
@@ -67,7 +67,7 @@ func TestError(t *testing.T) {
 	}
 	addrs := strings.Split(os.Getenv("ETCD_ADDR"), ",")
 	var (
-		r   *Remote
+		r   *ETCD
 		err error
 	)
 
@@ -126,7 +126,7 @@ func TestError(t *testing.T) {
 	g.Wait()
 }
 
-func put(r *Remote, val string) error {
+func put(r *ETCD, val string) error {
 	client, err := clientv3.New(*r.clientConfig)
 	if err != nil {
 		return err

--- a/config/remote/etcd/example_test.go
+++ b/config/remote/etcd/example_test.go
@@ -1,20 +1,22 @@
-package remote_test
+package etcd_test
 
 import (
 	"context"
+	"fmt"
 	"github.com/DoNewsCode/core"
-	"github.com/stretchr/testify/assert"
+	"github.com/DoNewsCode/core/codec/yaml"
+	"github.com/DoNewsCode/core/config"
+	"github.com/DoNewsCode/core/config/remote/etcd"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"os"
 	"strings"
-	"testing"
 	"time"
 )
 
-func Test_integration(t *testing.T) {
+func Example() {
 	addr := os.Getenv("ETCD_ADDR")
 	if addr == "" {
-		t.Skip("set ETCD_ADDR for run remote test")
+		fmt.Println("set ETCD_ADDR for run example")
 		return
 	}
 	key := "core.yaml"
@@ -23,13 +25,15 @@ func Test_integration(t *testing.T) {
 		Endpoints:   envEtcdAddrs,
 		DialTimeout: time.Second,
 	}
-	if err := put(cfg, key, "name: remote"); err != nil {
-		t.Fatal(err)
-	}
+	_ = put(cfg, key, "name: etcd")
 
-	c := core.New(core.WithRemoteYamlFile(key, cfg))
+	provider := etcd.Provider(key, &cfg)
+	c := core.New(core.WithConfigStack(provider, config.CodecParser{Codec: yaml.Codec{}}), core.WithConfigWatcher(provider))
 	c.ProvideEssentials()
-	assert.Equal(t, "remote", c.String("name"))
+	fmt.Println(c.String("name"))
+
+	// Output:
+	// etcd
 }
 
 func put(cfg clientv3.Config, key, val string) error {

--- a/config/remote/etcd/example_test.go
+++ b/config/remote/etcd/example_test.go
@@ -20,7 +20,7 @@ func Example() {
 	}
 	key := "core.yaml"
 	envEtcdAddrs := strings.Split(addr, ",")
-	cfg := &clientv3.Config{
+	cfg := clientv3.Config{
 		Endpoints:   envEtcdAddrs,
 		DialTimeout: time.Second,
 	}
@@ -34,8 +34,8 @@ func Example() {
 	// etcd
 }
 
-func put(cfg *clientv3.Config, key, val string) error {
-	client, err := clientv3.New(*cfg)
+func put(cfg clientv3.Config, key, val string) error {
+	client, err := clientv3.New(cfg)
 	if err != nil {
 		return err
 	}

--- a/config/remote/etcd/example_test.go
+++ b/config/remote/etcd/example_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/DoNewsCode/core"
 	"github.com/DoNewsCode/core/codec/yaml"
-	"github.com/DoNewsCode/core/config"
 	"github.com/DoNewsCode/core/config/remote/etcd"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"os"
@@ -21,14 +20,13 @@ func Example() {
 	}
 	key := "core.yaml"
 	envEtcdAddrs := strings.Split(addr, ",")
-	cfg := clientv3.Config{
+	cfg := &clientv3.Config{
 		Endpoints:   envEtcdAddrs,
 		DialTimeout: time.Second,
 	}
 	_ = put(cfg, key, "name: etcd")
 
-	provider := etcd.Provider(key, &cfg)
-	c := core.New(core.WithConfigStack(provider, config.CodecParser{Codec: yaml.Codec{}}), core.WithConfigWatcher(provider))
+	c := core.New(etcd.WithKey(cfg, key, yaml.Codec{}))
 	c.ProvideEssentials()
 	fmt.Println(c.String("name"))
 
@@ -36,8 +34,8 @@ func Example() {
 	// etcd
 }
 
-func put(cfg clientv3.Config, key, val string) error {
-	client, err := clientv3.New(cfg)
+func put(cfg *clientv3.Config, key, val string) error {
+	client, err := clientv3.New(*cfg)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
ETCD is only one of the remote config implementations. It should not be called package remote.

Also core should not import stuff from etcd. It unnecessarily bloats build size.