### PR TITLE
config and log rearchitect

### DIFF
--- a/config/app_name_test.go
+++ b/config/app_name_test.go
@@ -8,8 +8,8 @@ import (
 
 func TestNewAppNameFromConf(t *testing.T) {
 	t.Parallel()
-	app := NewAppNameFromConf(MapAdapter(map[string]interface{}{
+	app := NewAppNameFromConf(WithAccessor(MapAdapter(map[string]interface{}{
 		"name": "app",
-	}))
+	})))
 	assert.Equal(t, "app", app.String())
 }

--- a/config/config.go
+++ b/config/config.go
@@ -315,10 +315,7 @@ func (w wrappedConfigAccessor) Strings(s string) []string {
 
 func (w wrappedConfigAccessor) Bool(s string) bool {
 	var o bool
-	err := w.unmarshaler.Unmarshal(s, &o)
-	if err != nil {
-		panic(err)
-	}
+	w.unmarshaler.Unmarshal(s, &o)
 	return o
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -243,6 +243,7 @@ func (m MapAdapter) Unmarshal(path string, o interface{}) (err error) {
 	})
 }
 
+// Route implements contract.ConfigRouter
 func (m MapAdapter) Route(s string) contract.ConfigUnmarshaler {
 	var v interface{}
 	v = m
@@ -339,6 +340,8 @@ func (w wrappedConfigAccessor) Duration(s string) time.Duration {
 	return dur.Duration
 }
 
+// WithAccessor upgrade contract.ConfigUnmarshaler to contract.ConfigAccessor by
+// wrapping the original unmarshaler.
 func WithAccessor(unmarshaler contract.ConfigUnmarshaler) contract.ConfigAccessor {
 	if accessor, ok := unmarshaler.(contract.ConfigAccessor); ok {
 		return accessor

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -207,7 +207,7 @@ func TestUpgrade(t *gotesting.T) {
 	assert.Equal(t, false, upgraded.Bool("foo"))
 	assert.Equal(t, "bar", upgraded.Get("foo"))
 	assert.Equal(t, []string{"bar"}, upgraded.Strings("foo"))
-	assert.Equal(t, 0, upgraded.Duration("foo"))
+	assert.Equal(t, time.Duration(0), upgraded.Duration("foo"))
 }
 
 func prepareJSONTestSubject(t *gotesting.T) *KoanfAdapter {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -207,6 +207,7 @@ func TestUpgrade(t *gotesting.T) {
 	assert.Equal(t, false, upgraded.Bool("foo"))
 	assert.Equal(t, "bar", upgraded.Get("foo"))
 	assert.Equal(t, []string{"bar"}, upgraded.Strings("foo"))
+	assert.Equal(t, 0, upgraded.Duration("foo"))
 }
 
 func prepareJSONTestSubject(t *gotesting.T) *KoanfAdapter {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -146,46 +146,6 @@ func TestKoanfAdapter_Unmarshal_Yaml(t *gotesting.T) {
 	assert.Equal(t, r, Duration{1 * time.Nanosecond})
 }
 
-func TestMapAdapter_Bool(t *gotesting.T) {
-	t.Parallel()
-	k := MapAdapter(
-		map[string]interface{}{
-			"bool": true,
-		},
-	)
-	assert.True(t, k.Bool("bool"))
-}
-
-func TestMapAdapter_String(t *gotesting.T) {
-	t.Parallel()
-	k := MapAdapter(
-		map[string]interface{}{
-			"string": "string",
-		},
-	)
-	assert.Equal(t, "string", k.String("string"))
-}
-
-func TestMapAdapter_Float64(t *gotesting.T) {
-	t.Parallel()
-	k := MapAdapter(
-		map[string]interface{}{
-			"float": 1.0,
-		},
-	)
-	assert.Equal(t, 1.0, k.Float64("float"))
-}
-
-func TestMapAdapter_Get(t *gotesting.T) {
-	t.Parallel()
-	k := MapAdapter(
-		map[string]interface{}{
-			"float": 1.0,
-		},
-	)
-	assert.Equal(t, 1.0, k.Get("float"))
-}
-
 func TestMapAdapter_Route(t *gotesting.T) {
 	t.Parallel()
 	m := MapAdapter(
@@ -229,6 +189,18 @@ func TestKoanfAdapter_Reload(t *gotesting.T) {
 	)
 	assert.Error(t, err)
 	assert.Nil(t, conf)
+}
+
+func TestUpgrade(t *gotesting.T) {
+	var m MapAdapter = map[string]interface{}{"foo": "bar"}
+	upgraded := WithAccessor(m)
+
+	assert.Equal(t, float64(0), upgraded.Float64("foo"))
+	assert.Equal(t, 0, upgraded.Int("foo"))
+	assert.Equal(t, "bar", upgraded.String("foo"))
+	assert.Equal(t, false, upgraded.Bool("foo"))
+	assert.Equal(t, "bar", upgraded.Get("foo"))
+	assert.Equal(t, []string{"bar"}, upgraded.Strings("foo"))
 }
 
 func prepareJSONTestSubject(t *gotesting.T) *KoanfAdapter {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -110,6 +110,12 @@ func TestKoanfAdapter_Get(t *gotesting.T) {
 	assert.Equal(t, 1.0, k.Get("float"))
 }
 
+func TestKoanfAdapter_Duration(t *gotesting.T) {
+	t.Parallel()
+	k := prepareJSONTestSubject(t)
+	assert.Equal(t, time.Second, k.Duration("duration_string"))
+}
+
 func TestKoanfAdapter_Unmarshal_Json(t *gotesting.T) {
 	t.Parallel()
 	ka := prepareJSONTestSubject(t)

--- a/config/env.go
+++ b/config/env.go
@@ -76,7 +76,8 @@ func NewEnv(env string) Env {
 }
 
 // NewEnvFromConf reads the name of application from configuration's "env" entry.
-func NewEnvFromConf(conf contract.ConfigAccessor) Env {
-	envStr := conf.String("env")
+func NewEnvFromConf(conf contract.ConfigUnmarshaler) Env {
+	var envStr string
+	conf.Unmarshal("env", &envStr)
 	return NewEnv(envStr)
 }

--- a/contract/codec.go
+++ b/contract/codec.go
@@ -1,10 +1,5 @@
 package contract
 
-// Marshaller is an interface for the data type that knows how to marshal itself.
-type Marshaller interface {
-	Marshal() ([]byte, error)
-}
-
 // Codec is an interface for serialization and deserialization.
 type Codec interface {
 	Unmarshal(data []byte, value interface{}) error

--- a/contract/config.go
+++ b/contract/config.go
@@ -4,19 +4,30 @@ import "context"
 
 // ConfigRouter enables modular configuration by giving every piece of configuration a path.
 type ConfigRouter interface {
-	Route(path string) ConfigAccessor
+	Route(path string) ConfigUnmarshaler
 }
 
-// ConfigAccessor models a the basic configuration. If the configuration is hot reloaded,
-// ConfigAccessor should fetch the latest info.
+// ConfigUnmarshaler is a minimum config interface that can be used to retrieve
+// configuration from external system. If the configuration is hot reloaded,
+// ConfigUnmarshaler should fetch the latest info.
+type ConfigUnmarshaler interface {
+	Unmarshal(path string, o interface{}) error
+}
+
+// ConfigAccessor builds upon the ConfigUnmarshaler and provides a richer set of
+// API.
+// Note: it is recommended to inject ConfigUnmarshaler as the dependency
+// and call config.Upgrade to get the ConfigAccessor. The interface area of
+// ConfigUnmarshaler is much smaller and thus much easier to customize.
 type ConfigAccessor interface {
+	ConfigUnmarshaler
+
 	String(string) string
 	Int(string) int
 	Strings(string) []string
 	Bool(string) bool
 	Get(string) interface{}
 	Float64(string) float64
-	Unmarshal(path string, o interface{}) error
 }
 
 // ConfigWatcher is an interface for hot-reload provider.

--- a/contract/config.go
+++ b/contract/config.go
@@ -1,6 +1,9 @@
 package contract
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // ConfigRouter enables modular configuration by giving every piece of configuration a path.
 type ConfigRouter interface {
@@ -28,6 +31,7 @@ type ConfigAccessor interface {
 	Bool(string) bool
 	Get(string) interface{}
 	Float64(string) float64
+	Duration(string) time.Duration
 }
 
 // ConfigWatcher is an interface for hot-reload provider.

--- a/contract/log.go
+++ b/contract/log.go
@@ -1,0 +1,23 @@
+package contract
+
+import "github.com/go-kit/kit/log"
+
+// Logger is an alias of go kit logger
+type Logger = log.Logger
+
+// LevelLogger is plaintext logger with level.
+type LevelLogger interface {
+	Logger
+	Debug(args ...interface{})
+	Info(args ...interface{})
+	Warn(args ...interface{})
+	Err(args ...interface{})
+	Debugf(template string, args ...interface{})
+	Infof(template string, args ...interface{})
+	Warnf(template string, args ...interface{})
+	Errf(template string, args ...interface{})
+	Debugw(msg string, fields ...interface{})
+	Infow(msg string, fields ...interface{})
+	Warnw(msg string, fields ...interface{})
+	Errw(msg string, fields ...interface{})
+}

--- a/default_config.go
+++ b/default_config.go
@@ -42,7 +42,7 @@ gorm:
 `
 
 // ProvideConfig is the default ConfigProvider for package Core.
-func ProvideConfig(configStack []config.ProviderSet, configWatcher contract.ConfigWatcher) contract.ConfigAccessor {
+func ProvideConfig(configStack []config.ProviderSet, configWatcher contract.ConfigWatcher) contract.ConfigUnmarshaler {
 	var (
 		stack []config.Option
 		err   error
@@ -65,12 +65,12 @@ func ProvideConfig(configStack []config.ProviderSet, configWatcher contract.Conf
 }
 
 // ProvideEnv is the default EnvProvider for package Core.
-func ProvideEnv(conf contract.ConfigAccessor) contract.Env {
+func ProvideEnv(conf contract.ConfigUnmarshaler) contract.Env {
 	return config.NewEnvFromConf(conf)
 }
 
 // ProvideAppName is the default AppNameProvider for package Core.
-func ProvideAppName(conf contract.ConfigAccessor) contract.AppName {
+func ProvideAppName(conf contract.ConfigUnmarshaler) contract.AppName {
 	var appName config.AppName
 	err := conf.Unmarshal("name", &appName)
 	if err != nil {
@@ -80,7 +80,7 @@ func ProvideAppName(conf contract.ConfigAccessor) contract.AppName {
 }
 
 // ProvideLogger is the default LoggerProvider for package Core.
-func ProvideLogger(conf contract.ConfigAccessor, appName contract.AppName, env contract.Env) log.Logger {
+func ProvideLogger(conf contract.ConfigUnmarshaler, appName contract.AppName, env contract.Env) log.Logger {
 	var (
 		lvl    string
 		format string
@@ -100,12 +100,12 @@ func ProvideLogger(conf contract.ConfigAccessor, appName contract.AppName, env c
 }
 
 // ProvideDi is the default DiProvider for package Core.
-func ProvideDi(conf contract.ConfigAccessor) DiContainer {
+func ProvideDi(conf contract.ConfigUnmarshaler) DiContainer {
 	return di.NewGraph()
 }
 
 // ProvideEventDispatcher is the default EventDispatcherProvider for package Core.
-func ProvideEventDispatcher(conf contract.ConfigAccessor) contract.Dispatcher {
+func ProvideEventDispatcher(conf contract.ConfigUnmarshaler) contract.Dispatcher {
 	return &events.SyncDispatcher{}
 }
 

--- a/leader/dependency.go
+++ b/leader/dependency.go
@@ -35,7 +35,7 @@ type in struct {
 
 	AppName    contract.AppName
 	Env        contract.Env
-	Config     contract.ConfigAccessor
+	Config     contract.ConfigUnmarshaler
 	Dispatcher contract.Dispatcher
 	Driver     Driver       `optional:"true"`
 	Maker      otetcd.Maker `optional:"true"`

--- a/logging/log.go
+++ b/logging/log.go
@@ -31,6 +31,9 @@ import (
 	"github.com/go-kit/kit/log/term"
 )
 
+// LevelLogger is an alias of contract.LevelLogger
+type LevelLogger = contract.LevelLogger
+
 var _ LevelLogger = (*levelLogger)(nil)
 
 // NewLogger constructs a log.Logger based on the given format. The support
@@ -151,23 +154,43 @@ func (l levelLogger) Warnf(s string, i ...interface{}) {
 
 func (l levelLogger) Errf(s string, i ...interface{}) {
 	s = fmt.Sprintf(s, i...)
-	_ = level.Error(l).Log("err", s)
+	_ = level.Error(l).Log("msg", s)
 }
 
-func (l levelLogger) Debug(s string) {
-	_ = level.Debug(l).Log("err", s)
+func (l levelLogger) Debugw(s string, fields ...interface{}) {
+	m := append(fields, "msg", s)
+	_ = level.Debug(l).Log(m...)
 }
 
-func (l levelLogger) Info(s string) {
-	_ = level.Info(l).Log("msg", s)
+func (l levelLogger) Infow(s string, fields ...interface{}) {
+	m := append(fields, "msg", s)
+	_ = level.Info(l).Log(m...)
 }
 
-func (l levelLogger) Warn(s string) {
-	_ = level.Warn(l).Log("msg", s)
+func (l levelLogger) Warnw(s string, fields ...interface{}) {
+	m := append(fields, "msg", s)
+	_ = level.Warn(l).Log(m...)
 }
 
-func (l levelLogger) Err(err string) {
-	_ = level.Error(l).Log("err", err)
+func (l levelLogger) Errw(s string, fields ...interface{}) {
+	m := append(fields, "msg", s)
+	_ = level.Error(l).Log(m...)
+}
+
+func (l levelLogger) Debug(args ...interface{}) {
+	_ = level.Debug(l).Log("msg", fmt.Sprint(args...))
+}
+
+func (l levelLogger) Info(args ...interface{}) {
+	_ = level.Info(l).Log("msg", fmt.Sprint(args...))
+}
+
+func (l levelLogger) Warn(args ...interface{}) {
+	_ = level.Warn(l).Log("msg", fmt.Sprint(args...))
+}
+
+func (l levelLogger) Err(args ...interface{}) {
+	_ = level.Error(l).Log("msg", fmt.Sprint(args...))
 }
 
 // WithLevel decorates the logger and returns a contract.LevelLogger.
@@ -176,22 +199,9 @@ func (l levelLogger) Err(err string) {
 // this will weakens the powerful abstraction of log.Logger. Only inject
 // log.Logger, and converts log.Logger to contract.LevelLogger within the
 // boundary of dependency consumer if desired.
-func WithLevel(logger log.Logger) levelLogger {
-	if l, ok := logger.(levelLogger); ok {
+func WithLevel(logger log.Logger) LevelLogger {
+	if l, ok := logger.(LevelLogger); ok {
 		return l
 	}
 	return levelLogger{log.With(logger, "caller", log.Caller(5))}
-}
-
-// LevelLogger is plaintext logger with level.
-type LevelLogger interface {
-	log.Logger
-	Debug(string)
-	Info(string)
-	Warn(string)
-	Err(string)
-	Debugf(string, ...interface{})
-	Infof(string, ...interface{})
-	Warnf(string, ...interface{})
-	Errf(string, ...interface{})
 }

--- a/logging/log_test.go
+++ b/logging/log_test.go
@@ -12,9 +12,17 @@ import (
 func TestWithLevel(t *testing.T) {
 	var buf bytes.Buffer
 	l := log.NewLogfmtLogger(&buf)
-	WithLevel(l).Debug("hi")
+	ll := WithLevel(l)
+	ll.Debug("hi")
 	// ensure the caller depth is correct
 	assert.Contains(t, buf.String(), "caller=log_test.go")
+	assert.Contains(t, buf.String(), "level=debug")
+
+	ll.Debugw("foo", "bar", "baz")
+	assert.Contains(t, buf.String(), "bar=baz")
+
+	ll.Debugf("foo%d", 1)
+	assert.Contains(t, buf.String(), "foo1")
 }
 
 func TestLevelFilter(t *testing.T) {

--- a/otes/dependency.go
+++ b/otes/dependency.go
@@ -2,6 +2,8 @@ package otes
 
 import (
 	"fmt"
+	"net/http"
+
 	"github.com/DoNewsCode/core/config"
 	"github.com/DoNewsCode/core/contract"
 	"github.com/DoNewsCode/core/di"
@@ -10,7 +12,6 @@ import (
 	"github.com/olivere/elastic/v7"
 	"github.com/opentracing/opentracing-go"
 	"go.uber.org/dig"
-	"net/http"
 )
 
 /*
@@ -39,7 +40,7 @@ type factoryIn struct {
 	dig.In
 
 	Logger      log.Logger
-	Conf        contract.ConfigAccessor
+	Conf        contract.ConfigUnmarshaler
 	Interceptor EsConfigInterceptor        `optional:"true"`
 	Tracer      opentracing.Tracer         `optional:"true"`
 	Options     []elastic.ClientOptionFunc `optional:"true"`

--- a/otetcd/dependency.go
+++ b/otetcd/dependency.go
@@ -40,7 +40,7 @@ type factoryIn struct {
 	di.In
 
 	Logger      log.Logger
-	Conf        contract.ConfigAccessor
+	Conf        contract.ConfigUnmarshaler
 	Interceptor EtcdConfigInterceptor `optional:"true"`
 	Tracer      opentracing.Tracer    `optional:"true"`
 	Dispatcher  contract.Dispatcher   `optional:"true"`

--- a/otgorm/dependency.go
+++ b/otgorm/dependency.go
@@ -86,7 +86,7 @@ func provideMemoryDatabase() *SQLite {
 type factoryIn struct {
 	di.In
 
-	Conf                  contract.ConfigAccessor
+	Conf                  contract.ConfigUnmarshaler
 	Logger                log.Logger
 	GormConfigInterceptor GormConfigInterceptor `optional:"true"`
 	Tracer                opentracing.Tracer    `optional:"true"`

--- a/otkafka/dependency.go
+++ b/otkafka/dependency.go
@@ -51,7 +51,7 @@ type factoryIn struct {
 	ReaderInterceptor ReaderInterceptor  `optional:"true"`
 	WriterInterceptor WriterInterceptor  `optional:"true"`
 	Tracer            opentracing.Tracer `optional:"true"`
-	Conf              contract.ConfigAccessor
+	Conf              contract.ConfigUnmarshaler
 	Logger            log.Logger
 	ReaderStats       *ReaderStats `optional:"true"`
 	WriterStats       *WriterStats `optional:"true"`

--- a/otmongo/dependency.go
+++ b/otmongo/dependency.go
@@ -42,7 +42,7 @@ type factoryIn struct {
 	dig.In
 
 	Logger      log.Logger
-	Conf        contract.ConfigAccessor
+	Conf        contract.ConfigUnmarshaler
 	Interceptor MongoConfigInterceptor `optional:"true"`
 	Tracer      opentracing.Tracer     `optional:"true"`
 	Dispatcher  contract.Dispatcher    `optional:"true"`

--- a/otredis/dependency.go
+++ b/otredis/dependency.go
@@ -44,7 +44,7 @@ type factoryIn struct {
 	di.In
 
 	Logger      log.Logger
-	Conf        contract.ConfigAccessor
+	Conf        contract.ConfigUnmarshaler
 	Interceptor RedisConfigurationInterceptor `optional:"true"`
 	Tracer      opentracing.Tracer            `optional:"true"`
 	Gauges      *Gauges                       `optional:"true"`

--- a/ots3/dependency.go
+++ b/ots3/dependency.go
@@ -51,7 +51,7 @@ type factoryIn struct {
 	di.In
 
 	Logger     log.Logger
-	Conf       contract.ConfigAccessor
+	Conf       contract.ConfigUnmarshaler
 	Tracer     opentracing.Tracer  `optional:"true"`
 	Dispatcher contract.Dispatcher `optional:"true"`
 }


### PR DESCRIPTION
This PR intends to build easy-to-use implementations on top of easy-to-extend interfaces, and bring the value of both to the package core.

The interface is easy to extend if there are very few methods. However, an interface with very few methods can be cumbersome to use. 

Easy to extend:

```go
type ConfigUnmarshaler interface {
	Unmarshal(path string, o interface{}) error
}

type Logger interface {
    Log(keyvals ...interface{}) error
}
```

Easy to use:

```go
type ConfigAccessor interface {
	ConfigUnmarshaler

	String(string) string
	Int(string) int
	Strings(string) []string
	Bool(string) bool
	Get(string) interface{}
	Float64(string) float64
}

type LevelLogger interface {
	Logger
	Debug(args ...interface{})
	Info(args ...interface{})
	Warn(args ...interface{})
	Err(args ...interface{})
	Debugf(template string, args ...interface{})
	Infof(template string, args ...interface{})
	Warnf(template string, args ...interface{})
	Errf(template string, args ...interface{})
	Debugw(msg string, fields ...interface{})
	Infow(msg string, fields ...interface{})
	Warnw(msg string, fields ...interface{})
	Errw(msg string, fields ...interface{})
}
```

This PR allows user to upgrade the easy-to-extend interfaces to easy-to-use interfaces with one wrapped method call:

```go
func WithAccessor(unmarshaler contract.ConfigUnmarshaler) contract.ConfigAccessor
func WithLevel(logger log.Logger) LevelLogger
```

So implementors only need to satisfy the minimum interfaces, but consumers are free to use the richer API provided by upgraded interfaces.



