### PR TITLE
feat: Use type safe metrics struct

### DIFF
--- a/observability/doc.go
+++ b/observability/doc.go
@@ -1,5 +1,5 @@
 /*
-Package observability provides a tracer and a histogram to measure all incoming
+Package observability provides a tracer and a Histogram to measure all incoming
 requests to the system.
 
 Introduction

--- a/observability/doc.go
+++ b/observability/doc.go
@@ -1,6 +1,5 @@
 /*
-Package observability provides a tracer and a Histogram to measure all incoming
-requests to the system.
+Package observability provides a tracer and a set of perdefined metrics to measure critical system stats.
 
 Introduction
 

--- a/observability/observability.go
+++ b/observability/observability.go
@@ -22,7 +22,8 @@ func Providers() di.Deps {
 	return di.Deps{
 		ProvideJaegerLogAdapter,
 		ProvideOpentracing,
-		ProvideHistogramMetrics,
+		ProvideHTTPRequestDurationSeconds,
+		ProvideGRPCRequestDurationSeconds,
 		ProvideGORMMetrics,
 		ProvideRedisMetrics,
 		ProvideKafkaReaderMetrics,

--- a/otgorm/gorm_metrics.go
+++ b/otgorm/gorm_metrics.go
@@ -25,32 +25,34 @@ type Gauges struct {
 }
 
 // DBName sets the dbname label of metrics.
-func (g Gauges) DBName(dbName string) Gauges {
-	g.dbName = dbName
-	return g
+func (g *Gauges) DBName(dbName string) *Gauges {
+	withValues := []string{"dbname", g.dbName}
+	return &Gauges{
+		Idle:   g.Idle.With(withValues...),
+		InUse:  g.InUse.With(withValues...),
+		Open:   g.Open.With(withValues...),
+		dbName: dbName,
+		driver: g.driver,
+	}
 }
 
 // Driver sets the driver label of metrics.
-func (g Gauges) Driver(driver string) Gauges {
-	g.driver = driver
-	return g
+func (g *Gauges) Driver(driver string) *Gauges {
+	withValues := []string{"driver", driver}
+	return &Gauges{
+		Idle:   g.Idle.With(withValues...),
+		InUse:  g.InUse.With(withValues...),
+		Open:   g.Open.With(withValues...),
+		dbName: g.dbName,
+		driver: driver,
+	}
 }
 
 // Observe records the DBStats collected. It should be called periodically.
-func (g Gauges) Observe(stats sql.DBStats) Gauges {
-	withValues := []string{"dbname", g.dbName, "driver", g.driver}
-	g.Idle.
-		With(withValues...).
-		Set(float64(stats.Idle))
-
-	g.InUse.
-		With(withValues...).
-		Set(float64(stats.InUse))
-
-	g.Open.
-		With(withValues...).
-		Set(float64(stats.OpenConnections))
-	return g
+func (g *Gauges) Observe(stats sql.DBStats) {
+	g.Idle.Set(float64(stats.Idle))
+	g.InUse.Set(float64(stats.InUse))
+	g.Open.Set(float64(stats.OpenConnections))
 }
 
 // newCollector creates a new database wrapper containing the name of the database,

--- a/otgorm/gorm_metrics.go
+++ b/otgorm/gorm_metrics.go
@@ -26,7 +26,7 @@ type Gauges struct {
 
 // DBName sets the dbname label of metrics.
 func (g *Gauges) DBName(dbName string) *Gauges {
-	withValues := []string{"dbname", g.dbName}
+	withValues := []string{"dbname", dbName}
 	return &Gauges{
 		Idle:   g.Idle.With(withValues...),
 		InUse:  g.InUse.With(withValues...),

--- a/otgorm/gorm_metrics_test.go
+++ b/otgorm/gorm_metrics_test.go
@@ -26,7 +26,7 @@ func TestCollector(t *testing.T) {
 		Idle:  m,
 		Open:  m,
 	}
-	m.EXPECT().With(gomock.Any()).Times(3).Return(m)
+	m.EXPECT().With(gomock.Any()).MinTimes(3).Return(m)
 	m.EXPECT().Set(gomock.Any()).Times(3)
 
 	c := core.New()

--- a/otgorm/module_test.go
+++ b/otgorm/module_test.go
@@ -106,15 +106,18 @@ func TestModule_ProvideRunGroup(t *testing.T) {
 	}
 
 	idle := mock_metrics.NewMockGauge(ctrl)
-	idle.EXPECT().With(withValues...).Return(idle).MinTimes(1)
+	idle.EXPECT().With(withValues[0:2]...).Return(idle).MinTimes(1)
+	idle.EXPECT().With(withValues[2:4]...).Return(idle).MinTimes(1)
 	idle.EXPECT().Set(gomock.Eq(0.0)).MinTimes(1)
 
 	open := mock_metrics.NewMockGauge(ctrl)
-	open.EXPECT().With(withValues...).Return(open).MinTimes(1)
+	open.EXPECT().With(withValues[0:2]...).Return(open).MinTimes(1)
+	open.EXPECT().With(withValues[2:4]...).Return(open).MinTimes(1)
 	open.EXPECT().Set(gomock.Eq(2.0)).MinTimes(1)
 
 	inUse := mock_metrics.NewMockGauge(ctrl)
-	inUse.EXPECT().With(withValues...).Return(inUse).MinTimes(1)
+	inUse.EXPECT().With(withValues[0:2]...).Return(inUse).MinTimes(1)
+	inUse.EXPECT().With(withValues[2:4]...).Return(inUse).MinTimes(1)
 	inUse.EXPECT().Set(gomock.Eq(2.0)).MinTimes(1)
 
 	c := core.New(

--- a/otkafka/reader_metrics.go
+++ b/otkafka/reader_metrics.go
@@ -48,14 +48,55 @@ type ReaderStats struct {
 }
 
 // Reader sets the writer label in WriterStats.
-func (r ReaderStats) Reader(reader string) ReaderStats {
-	r.reader = reader
-	return r
+func (r *ReaderStats) Reader(reader string) *ReaderStats {
+	withValues := []string{"reader", reader}
+	return &ReaderStats{
+		Dials:         r.Dials.With(withValues...),
+		Fetches:       r.Fetches.With(withValues...),
+		Messages:      r.Messages.With(withValues...),
+		Bytes:         r.Bytes.With(withValues...),
+		Rebalances:    r.Rebalances.With(withValues...),
+		Timeouts:      r.Timeouts.With(withValues...),
+		Errors:        r.Errors.With(withValues...),
+		Offset:        r.Offset.With(withValues...),
+		Lag:           r.Lag.With(withValues...),
+		MinBytes:      r.MinBytes.With(withValues...),
+		MaxBytes:      r.MaxBytes.With(withValues...),
+		MaxWait:       r.MaxWait.With(withValues...),
+		QueueLength:   r.QueueLength.With(withValues...),
+		QueueCapacity: r.QueueCapacity.With(withValues...),
+		DialTime: AggStats{
+			Min: r.DialTime.Min.With(withValues...),
+			Max: r.DialTime.Max.With(withValues...),
+			Avg: r.DialTime.Avg.With(withValues...),
+		},
+		ReadTime: AggStats{
+			Min: r.ReadTime.Min.With(withValues...),
+			Max: r.ReadTime.Max.With(withValues...),
+			Avg: r.ReadTime.Avg.With(withValues...),
+		},
+		WaitTime: AggStats{
+			Min: r.WaitTime.Min.With(withValues...),
+			Max: r.WaitTime.Max.With(withValues...),
+			Avg: r.WaitTime.Avg.With(withValues...),
+		},
+		FetchSize: AggStats{
+			Min: r.FetchSize.Min.With(withValues...),
+			Max: r.FetchSize.Max.With(withValues...),
+			Avg: r.FetchSize.Avg.With(withValues...),
+		},
+		FetchBytes: AggStats{
+			Min: r.FetchBytes.Min.With(withValues...),
+			Max: r.FetchBytes.Max.With(withValues...),
+			Avg: r.FetchBytes.Avg.With(withValues...),
+		},
+		reader: reader,
+	}
 }
 
 // Observe records the reader stats. It should be called periodically.
-func (r ReaderStats) Observe(stats kafka.ReaderStats) {
-	withValues := []string{"reader", r.reader, "client_id", stats.ClientID, "topic", stats.Topic, "partition", stats.Partition}
+func (r *ReaderStats) Observe(stats kafka.ReaderStats) {
+	withValues := []string{"client_id", stats.ClientID, "topic", stats.Topic, "partition", stats.Partition}
 	r.Dials.With(withValues...).Add(float64(stats.Dials))
 	r.Fetches.With(withValues...).Add(float64(stats.Fetches))
 	r.Messages.With(withValues...).Add(float64(stats.Messages))

--- a/otkafka/writer_metrics.go
+++ b/otkafka/writer_metrics.go
@@ -34,6 +34,61 @@ type WriterStats struct {
 	Retries    AggStats
 	BatchSize  AggStats
 	BatchBytes AggStats
+
+	writer string
+}
+
+// Writer sets the writer label in WriterStats.
+func (w WriterStats) Writer(writer string) WriterStats {
+	w.writer = writer
+	return w
+}
+
+// Observe records the writer stats. It should called periodically.
+func (w WriterStats) Observe(stats kafka.WriterStats) WriterStats {
+	withValues := []string{"writer", w.writer, "topic", stats.Topic}
+
+	w.Writes.With(withValues...).Add(float64(stats.Writes))
+	w.Messages.With(withValues...).Add(float64(stats.Messages))
+	w.Bytes.With(withValues...).Add(float64(stats.Bytes))
+	w.Errors.With(withValues...).Add(float64(stats.Errors))
+
+	w.BatchTime.Min.With(withValues...).Add(stats.BatchTime.Min.Seconds())
+	w.BatchTime.Max.With(withValues...).Add(stats.BatchTime.Max.Seconds())
+	w.BatchTime.Avg.With(withValues...).Add(stats.BatchTime.Avg.Seconds())
+
+	w.WriteTime.Min.With(withValues...).Add(stats.WriteTime.Min.Seconds())
+	w.WriteTime.Max.With(withValues...).Add(stats.WriteTime.Max.Seconds())
+	w.WriteTime.Avg.With(withValues...).Add(stats.WriteTime.Avg.Seconds())
+
+	w.WaitTime.Min.With(withValues...).Add(stats.WaitTime.Min.Seconds())
+	w.WaitTime.Max.With(withValues...).Add(stats.WaitTime.Max.Seconds())
+	w.WaitTime.Avg.With(withValues...).Add(stats.WaitTime.Avg.Seconds())
+
+	w.Retries.Min.With(withValues...).Add(float64(stats.Retries.Min))
+	w.Retries.Max.With(withValues...).Add(float64(stats.Retries.Max))
+	w.Retries.Avg.With(withValues...).Add(float64(stats.Retries.Avg))
+
+	w.BatchSize.Min.With(withValues...).Add(float64(stats.BatchSize.Min))
+	w.BatchSize.Max.With(withValues...).Add(float64(stats.BatchSize.Max))
+	w.BatchSize.Avg.With(withValues...).Add(float64(stats.BatchSize.Avg))
+
+	w.BatchBytes.Min.With(withValues...).Add(float64(stats.BatchBytes.Min))
+	w.BatchBytes.Max.With(withValues...).Add(float64(stats.BatchBytes.Max))
+	w.BatchBytes.Avg.With(withValues...).Add(float64(stats.BatchBytes.Avg))
+
+	w.MaxAttempts.With(withValues...).Set(float64(stats.MaxAttempts))
+	w.MaxBatchSize.With(withValues...).Set(float64(stats.MaxBatchSize))
+	w.BatchTimeout.With(withValues...).Set(stats.BatchTimeout.Seconds())
+	w.ReadTimeout.With(withValues...).Set(stats.ReadTimeout.Seconds())
+	w.WriteTimeout.With(withValues...).Set(stats.WriteTimeout.Seconds())
+	w.RequiredAcks.With(withValues...).Set(float64(stats.RequiredAcks))
+	var async float64
+	if stats.Async {
+		async = 1.0
+	}
+	w.Async.With(withValues...).Set(async)
+	return w
 }
 
 // newCollector creates a new kafka writer wrapper containing the name of the reader.
@@ -50,47 +105,6 @@ func (d *writerCollector) collectConnectionStats() {
 	for k, v := range d.factory.List() {
 		writer := v.Conn.(*kafka.Writer)
 		stats := writer.Stats()
-		withValues := []string{"writer", k, "topic", stats.Topic}
-
-		d.stats.Writes.With(withValues...).Add(float64(stats.Writes))
-		d.stats.Messages.With(withValues...).Add(float64(stats.Messages))
-		d.stats.Bytes.With(withValues...).Add(float64(stats.Bytes))
-		d.stats.Errors.With(withValues...).Add(float64(stats.Errors))
-
-		d.stats.BatchTime.Min.With(withValues...).Add(stats.BatchTime.Min.Seconds())
-		d.stats.BatchTime.Max.With(withValues...).Add(stats.BatchTime.Max.Seconds())
-		d.stats.BatchTime.Avg.With(withValues...).Add(stats.BatchTime.Avg.Seconds())
-
-		d.stats.WriteTime.Min.With(withValues...).Add(stats.WriteTime.Min.Seconds())
-		d.stats.WriteTime.Max.With(withValues...).Add(stats.WriteTime.Max.Seconds())
-		d.stats.WriteTime.Avg.With(withValues...).Add(stats.WriteTime.Avg.Seconds())
-
-		d.stats.WaitTime.Min.With(withValues...).Add(stats.WaitTime.Min.Seconds())
-		d.stats.WaitTime.Max.With(withValues...).Add(stats.WaitTime.Max.Seconds())
-		d.stats.WaitTime.Avg.With(withValues...).Add(stats.WaitTime.Avg.Seconds())
-
-		d.stats.Retries.Min.With(withValues...).Add(float64(stats.Retries.Min))
-		d.stats.Retries.Max.With(withValues...).Add(float64(stats.Retries.Max))
-		d.stats.Retries.Avg.With(withValues...).Add(float64(stats.Retries.Avg))
-
-		d.stats.BatchSize.Min.With(withValues...).Add(float64(stats.BatchSize.Min))
-		d.stats.BatchSize.Max.With(withValues...).Add(float64(stats.BatchSize.Max))
-		d.stats.BatchSize.Avg.With(withValues...).Add(float64(stats.BatchSize.Avg))
-
-		d.stats.BatchBytes.Min.With(withValues...).Add(float64(stats.BatchBytes.Min))
-		d.stats.BatchBytes.Max.With(withValues...).Add(float64(stats.BatchBytes.Max))
-		d.stats.BatchBytes.Avg.With(withValues...).Add(float64(stats.BatchBytes.Avg))
-
-		d.stats.MaxAttempts.With(withValues...).Set(float64(stats.MaxAttempts))
-		d.stats.MaxBatchSize.With(withValues...).Set(float64(stats.MaxBatchSize))
-		d.stats.BatchTimeout.With(withValues...).Set(stats.BatchTimeout.Seconds())
-		d.stats.ReadTimeout.With(withValues...).Set(stats.ReadTimeout.Seconds())
-		d.stats.WriteTimeout.With(withValues...).Set(stats.WriteTimeout.Seconds())
-		d.stats.RequiredAcks.With(withValues...).Set(float64(stats.RequiredAcks))
-		var async float64
-		if stats.Async {
-			async = 1.0
-		}
-		d.stats.Async.With(withValues...).Set(async)
+		d.stats.Writer(k).Observe(stats)
 	}
 }

--- a/otkafka/writer_metrics.go
+++ b/otkafka/writer_metrics.go
@@ -62,10 +62,20 @@ func (w *WriterStats) Writer(writer string) *WriterStats {
 			Max: w.WriteTime.Max.With(withValues...),
 			Avg: w.WriteTime.Avg.With(withValues...),
 		},
+		Retries: AggStats{
+			Min: w.Retries.Min.With(withValues...),
+			Max: w.Retries.Max.With(withValues...),
+			Avg: w.Retries.Avg.With(withValues...),
+		},
 		WaitTime: AggStats{
 			Min: w.WaitTime.Min.With(withValues...),
 			Max: w.WaitTime.Max.With(withValues...),
 			Avg: w.WaitTime.Avg.With(withValues...),
+		},
+		BatchSize: AggStats{
+			Min: w.BatchSize.Min.With(withValues...),
+			Max: w.BatchSize.Max.With(withValues...),
+			Avg: w.BatchSize.Avg.With(withValues...),
 		},
 		BatchBytes: AggStats{
 			Min: w.BatchBytes.Min.With(withValues...),

--- a/otkafka/writer_metrics.go
+++ b/otkafka/writer_metrics.go
@@ -39,14 +39,47 @@ type WriterStats struct {
 }
 
 // Writer sets the writer label in WriterStats.
-func (w WriterStats) Writer(writer string) WriterStats {
-	w.writer = writer
-	return w
+func (w *WriterStats) Writer(writer string) *WriterStats {
+	withValues := []string{"writer", writer}
+	return &WriterStats{
+		Writes:       w.Writes.With(withValues...),
+		Messages:     w.Messages.With(withValues...),
+		Bytes:        w.Bytes.With(withValues...),
+		Errors:       w.Errors.With(withValues...),
+		MaxAttempts:  w.MaxAttempts.With(withValues...),
+		MaxBatchSize: w.MaxBatchSize.With(withValues...),
+		BatchTimeout: w.BatchTimeout.With(withValues...),
+		ReadTimeout:  w.ReadTimeout.With(withValues...),
+		WriteTimeout: w.WriteTimeout.With(withValues...),
+		RequiredAcks: w.RequiredAcks.With(withValues...),
+		BatchTime: AggStats{
+			Min: w.BatchTime.Min.With(withValues...),
+			Max: w.BatchTime.Max.With(withValues...),
+			Avg: w.BatchTime.Avg.With(withValues...),
+		},
+		WriteTime: AggStats{
+			Min: w.WriteTime.Min.With(withValues...),
+			Max: w.WriteTime.Max.With(withValues...),
+			Avg: w.WriteTime.Avg.With(withValues...),
+		},
+		WaitTime: AggStats{
+			Min: w.WaitTime.Min.With(withValues...),
+			Max: w.WaitTime.Max.With(withValues...),
+			Avg: w.WaitTime.Avg.With(withValues...),
+		},
+		BatchBytes: AggStats{
+			Min: w.BatchBytes.Min.With(withValues...),
+			Max: w.BatchBytes.Max.With(withValues...),
+			Avg: w.BatchBytes.Avg.With(withValues...),
+		},
+		Async:  w.Async.With(withValues...),
+		writer: writer,
+	}
 }
 
 // Observe records the writer stats. It should called periodically.
-func (w WriterStats) Observe(stats kafka.WriterStats) WriterStats {
-	withValues := []string{"writer", w.writer, "topic", stats.Topic}
+func (w *WriterStats) Observe(stats kafka.WriterStats) *WriterStats {
+	withValues := []string{"topic", stats.Topic}
 
 	w.Writes.With(withValues...).Add(float64(stats.Writes))
 	w.Messages.With(withValues...).Add(float64(stats.Messages))

--- a/otredis/metrics.go
+++ b/otredis/metrics.go
@@ -28,38 +28,33 @@ type Gauges struct {
 }
 
 // DBName sets the dbname label of redis metrics.
-func (r Gauges) DBName(dbName string) Gauges {
-	r.dbName = dbName
-	return r
+func (g *Gauges) DBName(dbName string) *Gauges {
+	withValues := []string{"dbname", dbName}
+	return &Gauges{
+		Hits:       g.Hits.With(withValues...),
+		Misses:     g.Misses.With(withValues...),
+		Timeouts:   g.Timeouts.With(withValues...),
+		TotalConns: g.TotalConns.With(withValues...),
+		IdleConns:  g.IdleConns.With(withValues...),
+		StaleConns: g.StaleConns.With(withValues...),
+		dbName:     dbName,
+	}
 }
 
 // Observe records the redis pool stats. It should be called periodically.
-func (r Gauges) Observe(stats *redis.PoolStats) {
-	withValues := []string{"dbname", r.dbName}
+func (g *Gauges) Observe(stats *redis.PoolStats) {
 
-	r.Hits.
-		With(withValues...).
-		Set(float64(stats.Hits))
+	g.Hits.Set(float64(stats.Hits))
 
-	r.Misses.
-		With(withValues...).
-		Set(float64(stats.Misses))
+	g.Misses.Set(float64(stats.Misses))
 
-	r.Timeouts.
-		With(withValues...).
-		Set(float64(stats.Timeouts))
+	g.Timeouts.Set(float64(stats.Timeouts))
 
-	r.TotalConns.
-		With(withValues...).
-		Set(float64(stats.TotalConns))
+	g.TotalConns.Set(float64(stats.TotalConns))
 
-	r.IdleConns.
-		With(withValues...).
-		Set(float64(stats.IdleConns))
+	g.IdleConns.Set(float64(stats.IdleConns))
 
-	r.StaleConns.
-		With(withValues...).
-		Set(float64(stats.StaleConns))
+	g.StaleConns.Set(float64(stats.StaleConns))
 }
 
 // newCollector creates a new redis wrapper containing the name of the redis.

--- a/srvgrpc/metrics.go
+++ b/srvgrpc/metrics.go
@@ -48,24 +48,36 @@ type RequestDurationSeconds struct {
 }
 
 // Module specifies the module label for RequestDurationSeconds.
-func (r RequestDurationSeconds) Module(module string) RequestDurationSeconds {
-	r.module = module
-	return r
+func (r *RequestDurationSeconds) Module(module string) *RequestDurationSeconds {
+	return &RequestDurationSeconds{
+		Histogram: r.Histogram.With("module", module),
+		module:    module,
+		service:   r.service,
+		route:     r.route,
+	}
 }
 
 // Service specifies the service label for RequestDurationSeconds.
-func (r RequestDurationSeconds) Service(service string) RequestDurationSeconds {
-	r.service = service
-	return r
+func (r *RequestDurationSeconds) Service(service string) *RequestDurationSeconds {
+	return &RequestDurationSeconds{
+		Histogram: r.Histogram.With("service", service),
+		module:    r.module,
+		service:   service,
+		route:     r.route,
+	}
 }
 
 // Route specifies the method label for RequestDurationSeconds.
-func (r RequestDurationSeconds) Route(route string) RequestDurationSeconds {
-	r.route = route
-	return r
+func (r *RequestDurationSeconds) Route(route string) *RequestDurationSeconds {
+	return &RequestDurationSeconds{
+		Histogram: r.Histogram.With("route", route),
+		module:    r.module,
+		service:   r.service,
+		route:     route,
+	}
 }
 
 // Observe records the time taken to process the request.
 func (r RequestDurationSeconds) Observe(seconds float64) {
-	r.Histogram.With("module", r.module, "service", r.service, "route", r.route).Observe(seconds)
+	r.Histogram.Observe(seconds)
 }

--- a/srvgrpc/metrics.go
+++ b/srvgrpc/metrics.go
@@ -1,6 +1,10 @@
 package srvgrpc
 
 import (
+	"context"
+	"time"
+
+	"github.com/go-kit/kit/metrics"
 	"github.com/grpc-ecosystem/go-grpc-prometheus"
 	"google.golang.org/grpc"
 )
@@ -19,4 +23,48 @@ type MetricsModule struct{}
 // ProvideGRPC implements container.GRPCProvider
 func (m MetricsModule) ProvideGRPC(server *grpc.Server) {
 	grpc_prometheus.Register(server)
+}
+
+func Metrics(metrics *RequestDurationSeconds) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+		start := time.Now()
+		defer func() {
+			metrics.Route(info.FullMethod).Observe(time.Since(start).Seconds())
+		}()
+		return handler(ctx, req)
+	}
+}
+
+// RequestDurationSeconds is a Histogram that measures the request latency.
+type RequestDurationSeconds struct {
+	// Histogram is the underlying histogram of RequestDurationSeconds.
+	Histogram metrics.Histogram
+
+	// labels
+	module  string
+	service string
+	route   string
+}
+
+// Module specifies the module label for RequestDurationSeconds.
+func (r RequestDurationSeconds) Module(module string) RequestDurationSeconds {
+	r.module = module
+	return r
+}
+
+// Service specifies the service label for RequestDurationSeconds.
+func (r RequestDurationSeconds) Service(service string) RequestDurationSeconds {
+	r.service = service
+	return r
+}
+
+// Method specifies the method label for RequestDurationSeconds.
+func (r RequestDurationSeconds) Route(route string) RequestDurationSeconds {
+	r.route = route
+	return r
+}
+
+// Observe records the time taken to process the request.
+func (r RequestDurationSeconds) Observe(seconds float64) {
+	r.Histogram.With("module", r.module, "service", r.service, "route", r.route).Observe(seconds)
 }

--- a/srvgrpc/metrics.go
+++ b/srvgrpc/metrics.go
@@ -25,6 +25,7 @@ func (m MetricsModule) ProvideGRPC(server *grpc.Server) {
 	grpc_prometheus.Register(server)
 }
 
+// Metrics is a unary interceptor for grpc package. It records the request duration in a histogram.
 func Metrics(metrics *RequestDurationSeconds) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
 		start := time.Now()
@@ -58,7 +59,7 @@ func (r RequestDurationSeconds) Service(service string) RequestDurationSeconds {
 	return r
 }
 
-// Method specifies the method label for RequestDurationSeconds.
+// Route specifies the method label for RequestDurationSeconds.
 func (r RequestDurationSeconds) Route(route string) RequestDurationSeconds {
 	r.route = route
 	return r

--- a/srvgrpc/metrics_test.go
+++ b/srvgrpc/metrics_test.go
@@ -1,0 +1,28 @@
+package srvgrpc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-kit/kit/metrics/generic"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+)
+
+func TestRequestDurationSeconds(t *testing.T) {
+	rds := RequestDurationSeconds{
+		Histogram: generic.NewHistogram("foo", 2),
+	}
+	rds = rds.Module("m").Service("s").Route("r")
+	rds.Observe(5)
+
+	assert.Equal(t, 5.0, rds.Histogram.(*generic.Histogram).Quantile(0.5))
+
+	f := grpc.UnaryHandler(func(ctx context.Context, req interface{}) (interface{}, error) {
+		time.Sleep(time.Millisecond)
+		return nil, nil
+	})
+	_, _ = Metrics(&rds)(context.Background(), nil, &grpc.UnaryServerInfo{FullMethod: "/"}, f)
+	assert.GreaterOrEqual(t, 1.0, rds.Histogram.(*generic.Histogram).Quantile(0.5))
+}

--- a/srvgrpc/metrics_test.go
+++ b/srvgrpc/metrics_test.go
@@ -11,18 +11,19 @@ import (
 )
 
 func TestRequestDurationSeconds(t *testing.T) {
-	rds := RequestDurationSeconds{
+	rds := &RequestDurationSeconds{
 		Histogram: generic.NewHistogram("foo", 2),
 	}
 	rds = rds.Module("m").Service("s").Route("r")
 	rds.Observe(5)
 
 	assert.Equal(t, 5.0, rds.Histogram.(*generic.Histogram).Quantile(0.5))
+	assert.ElementsMatch(t, []string{"module", "m", "service", "s", "route", "r"}, rds.Histogram.(*generic.Histogram).LabelValues())
 
 	f := grpc.UnaryHandler(func(ctx context.Context, req interface{}) (interface{}, error) {
 		time.Sleep(time.Millisecond)
 		return nil, nil
 	})
-	_, _ = Metrics(&rds)(context.Background(), nil, &grpc.UnaryServerInfo{FullMethod: "/"}, f)
+	_, _ = Metrics(rds)(context.Background(), nil, &grpc.UnaryServerInfo{FullMethod: "/"}, f)
 	assert.GreaterOrEqual(t, 1.0, rds.Histogram.(*generic.Histogram).Quantile(0.5))
 }

--- a/srvhttp/metrics.go
+++ b/srvhttp/metrics.go
@@ -18,6 +18,7 @@ func (m MetricsModule) ProvideHTTP(router *mux.Router) {
 	router.PathPrefix("/metrics").Handler(promhttp.Handler())
 }
 
+// Metrics is a unary interceptor for standard library http package. It records the request duration in a histogram.
 func Metrics(metrics *RequestDurationSeconds) func(handler http.Handler) http.Handler {
 	return func(handler http.Handler) http.Handler {
 		return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {

--- a/srvhttp/metrics.go
+++ b/srvhttp/metrics.go
@@ -53,24 +53,36 @@ type RequestDurationSeconds struct {
 }
 
 // Module specifies the module label for RequestDurationSeconds.
-func (r RequestDurationSeconds) Module(module string) RequestDurationSeconds {
-	r.module = module
-	return r
+func (r *RequestDurationSeconds) Module(module string) *RequestDurationSeconds {
+	return &RequestDurationSeconds{
+		Histogram: r.Histogram.With("module", module),
+		module:    module,
+		service:   r.service,
+		route:     r.route,
+	}
 }
 
 // Service specifies the service label for RequestDurationSeconds.
-func (r RequestDurationSeconds) Service(service string) RequestDurationSeconds {
-	r.service = service
-	return r
+func (r *RequestDurationSeconds) Service(service string) *RequestDurationSeconds {
+	return &RequestDurationSeconds{
+		Histogram: r.Histogram.With("service", service),
+		module:    r.module,
+		service:   service,
+		route:     r.route,
+	}
 }
 
 // Route specifies the method label for RequestDurationSeconds.
-func (r RequestDurationSeconds) Route(route string) RequestDurationSeconds {
-	r.route = route
-	return r
+func (r *RequestDurationSeconds) Route(route string) *RequestDurationSeconds {
+	return &RequestDurationSeconds{
+		Histogram: r.Histogram.With("route", route),
+		module:    r.module,
+		service:   r.service,
+		route:     route,
+	}
 }
 
 // Observe records the time taken to process the request.
-func (r RequestDurationSeconds) Observe(seconds float64) {
-	r.Histogram.With("module", r.module, "service", r.service, "route", r.route).Observe(seconds)
+func (r *RequestDurationSeconds) Observe(seconds float64) {
+	r.Histogram.Observe(seconds)
 }

--- a/srvhttp/metrics.go
+++ b/srvhttp/metrics.go
@@ -1,6 +1,10 @@
 package srvhttp
 
 import (
+	"net/http"
+	"time"
+
+	"github.com/go-kit/kit/metrics"
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
@@ -12,4 +16,60 @@ type MetricsModule struct{}
 // ProvideHTTP implements container.HTTPProvider
 func (m MetricsModule) ProvideHTTP(router *mux.Router) {
 	router.PathPrefix("/metrics").Handler(promhttp.Handler())
+}
+
+func Metrics(metrics *RequestDurationSeconds) func(handler http.Handler) http.Handler {
+	return func(handler http.Handler) http.Handler {
+		return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			start := time.Now()
+			defer func() {
+				route := mux.CurrentRoute(request)
+				if route == nil {
+					metrics.Route("").Observe(time.Since(start).Seconds())
+					return
+				}
+				path, err := route.GetPathTemplate()
+				if err != nil {
+					metrics.Route("").Observe(time.Since(start).Seconds())
+					return
+				}
+				metrics.Route(path).Observe(time.Since(start).Seconds())
+			}()
+			handler.ServeHTTP(writer, request)
+		})
+	}
+}
+
+// RequestDurationSeconds is a Histogram that measures the request latency.
+type RequestDurationSeconds struct {
+	// Histogram is the underlying histogram of RequestDurationSeconds.
+	Histogram metrics.Histogram
+
+	// labels
+	module  string
+	service string
+	route   string
+}
+
+// Module specifies the module label for RequestDurationSeconds.
+func (r RequestDurationSeconds) Module(module string) RequestDurationSeconds {
+	r.module = module
+	return r
+}
+
+// Service specifies the service label for RequestDurationSeconds.
+func (r RequestDurationSeconds) Service(service string) RequestDurationSeconds {
+	r.service = service
+	return r
+}
+
+// Route specifies the method label for RequestDurationSeconds.
+func (r RequestDurationSeconds) Route(route string) RequestDurationSeconds {
+	r.route = route
+	return r
+}
+
+// Observe records the time taken to process the request.
+func (r RequestDurationSeconds) Observe(seconds float64) {
+	r.Histogram.With("module", r.module, "service", r.service, "route", r.route).Observe(seconds)
 }

--- a/srvhttp/metrics_test.go
+++ b/srvhttp/metrics_test.go
@@ -11,18 +11,19 @@ import (
 )
 
 func TestRequestDurationSeconds(t *testing.T) {
-	rds := RequestDurationSeconds{
+	rds := &RequestDurationSeconds{
 		Histogram: generic.NewHistogram("foo", 2),
 	}
 	rds = rds.Module("m").Service("s").Route("r")
 	rds.Observe(5)
 
 	assert.Equal(t, 5.0, rds.Histogram.(*generic.Histogram).Quantile(0.5))
+	assert.ElementsMatch(t, []string{"module", "m", "service", "s", "route", "r"}, rds.Histogram.(*generic.Histogram).LabelValues())
 
 	f := http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		time.Sleep(time.Millisecond)
 	})
-	h := Metrics(&rds)(f)
+	h := Metrics(rds)(f)
 	h.ServeHTTP(nil, httptest.NewRequest(http.MethodGet, "/", nil))
 	assert.GreaterOrEqual(t, 1.0, rds.Histogram.(*generic.Histogram).Quantile(0.5))
 }

--- a/srvhttp/metrics_test.go
+++ b/srvhttp/metrics_test.go
@@ -1,0 +1,28 @@
+package srvhttp
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-kit/kit/metrics/generic"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequestDurationSeconds(t *testing.T) {
+	rds := RequestDurationSeconds{
+		Histogram: generic.NewHistogram("foo", 2),
+	}
+	rds = rds.Module("m").Service("s").Route("r")
+	rds.Observe(5)
+
+	assert.Equal(t, 5.0, rds.Histogram.(*generic.Histogram).Quantile(0.5))
+
+	f := http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		time.Sleep(time.Millisecond)
+	})
+	h := Metrics(&rds)(f)
+	h.ServeHTTP(nil, httptest.NewRequest(http.MethodGet, "/", nil))
+	assert.GreaterOrEqual(t, 1.0, rds.Histogram.(*generic.Histogram).Quantile(0.5))
+}


### PR DESCRIPTION
Make predefinedned metrics a dedicated type rather than an interface. This gives user more type safety. See https://medium.com/@sameer_74231/go-experience-report-for-generics-google-metrics-api-b019d597aaa4