### PR TITLE
fix: metrics add default interval

### DIFF
--- a/otgorm/dependency.go
+++ b/otgorm/dependency.go
@@ -218,7 +218,7 @@ func provideDBFactory(options *providersOption) func(p factoryIn) (databaseOut, 
 
 		var collector *collector
 		if factoryIn.Gauges != nil {
-			var interval time.Duration
+			var interval time.Duration = 15 * time.Second
 			factoryIn.Conf.Unmarshal("gormMetrics.interval", &interval)
 			collector = newCollector(dbFactory, factoryIn.Gauges, interval)
 		}

--- a/otgorm/module.go
+++ b/otgorm/module.go
@@ -11,8 +11,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const defaultInterval = 15 * time.Second
-
 // MigrationProvider is an interface for database migrations. modules
 // implementing this interface are migration providers. migrations will be
 // collected in migrate command.
@@ -49,14 +47,11 @@ type ModuleIn struct {
 
 // New creates a Module.
 func New(in ModuleIn) Module {
-	var duration time.Duration = defaultInterval
-	in.Conf.Unmarshal("gormMetrics.interval", &duration)
 	return Module{
 		maker:     in.Maker,
 		env:       in.Env,
 		logger:    in.Logger,
 		container: in.Container,
-		interval:  duration,
 	}
 }
 

--- a/otkafka/dependency.go
+++ b/otkafka/dependency.go
@@ -151,7 +151,7 @@ func provideKafkaFactory(option *providersOption) func(p factoryIn) (factoryOut,
 		}
 
 		if p.ReaderStats != nil || p.WriterStats != nil {
-			var interval time.Duration
+			var interval time.Duration = 15 * time.Second
 			p.Conf.Unmarshal("kafkaMetrics.interval", &interval)
 			if p.ReaderStats != nil {
 				readerCollector = newReaderCollector(rf, p.ReaderStats, interval)

--- a/otredis/dependency.go
+++ b/otredis/dependency.go
@@ -164,7 +164,7 @@ func provideRedisFactory(option *providersOption) func(p factoryIn) (factoryOut,
 		}
 		var collector *collector
 		if p.Gauges != nil {
-			var interval time.Duration
+			var interval time.Duration = 15 * time.Second
 			p.Conf.Unmarshal("redisMetrics.interval", &interval)
 			collector = newCollector(redisFactory, p.Gauges, interval)
 		}


### PR DESCRIPTION
When the value of interval is 0s, `time.NewTicker` will panic. 
However, in most cases, the user is not very concerned about the value of interval, so a default value is provided.