### PR TITLE
fix(logging): inconsistency between go kit Logger and spanLogger

### DIFF
--- a/logging/log_test.go
+++ b/logging/log_test.go
@@ -65,8 +65,8 @@ func TestSpanLogger(t *testing.T) {
 	spanLogger{
 		span: &mock,
 		base: log.NewNopLogger(),
-		kvs:  []interface{}{"foo", "bar"},
-	}.Log("baz", log.Valuer(func() interface{} { return "qux" }))
+		kvs:  []interface{}{"foo", log.Valuer(func() interface{} { return "bar" })},
+	}.Log("baz", "qux")
 
 	assert.Equal(t, []interface{}{"foo", "bar", "baz", "qux"}, mock.received)
 }


### PR DESCRIPTION
Only log.Valuer passed via log.With are treated as dynamic argument in go kit log. The change makes spanLogger consistent with go kit.