### PR TITLE
feat(observability): capture transport status

### DIFF
--- a/cronopts/jobs/universal.go
+++ b/cronopts/jobs/universal.go
@@ -57,7 +57,7 @@ func WithMetrics(metrics *cronopts.CronJobMetrics) func(universal Universal) Uni
 			Do: func(ctx context.Context) error {
 				start := time.Now()
 				metrics = metrics.Job(universal.Name)
-				defer metrics.Observe(time.Since(start).Seconds())
+				defer metrics.Observe(time.Since(start))
 				err := universal.Do(ctx)
 				if err != nil {
 					metrics.Fail()

--- a/cronopts/metrics.go
+++ b/cronopts/metrics.go
@@ -53,8 +53,8 @@ func (c *CronJobMetrics) Fail() {
 }
 
 // Observe records the duration of the job.
-func (c *CronJobMetrics) Observe(value float64) {
-	c.cronJobDurationSeconds.With("module", c.module, "job", c.job).Observe(value)
+func (c *CronJobMetrics) Observe(duration time.Duration) {
+	c.cronJobDurationSeconds.With("module", c.module, "job", c.job).Observe(duration.Seconds())
 }
 
 // Measure wraps the given job and records the duration and success.

--- a/internal/stub/metrics.go
+++ b/internal/stub/metrics.go
@@ -2,9 +2,22 @@ package stub
 
 import "github.com/go-kit/kit/metrics"
 
+// LabelValues contains the set of labels and their corresponding values.
+type LabelValues []string
+
+// Label returns the label of given name.
+func (l LabelValues) Label(name string) string {
+	for i := 0; i < len(l); i += 2 {
+		if l[i] == name {
+			return l[i+1]
+		}
+	}
+	return ""
+}
+
 // Histogram is a stub implementation of the go-kit metrics.Histogram interface.
 type Histogram struct {
-	LabelValues   []string
+	LabelValues   LabelValues
 	ObservedValue float64
 }
 

--- a/observability/example_test.go
+++ b/observability/example_test.go
@@ -22,6 +22,6 @@ func Example() {
 			Module("module").
 			Service("service").
 			Route("route").
-			Observe(time.Since(start).Seconds())
+			Observe(time.Since(start))
 	})
 }

--- a/observability/metrics.go
+++ b/observability/metrics.go
@@ -27,7 +27,7 @@ func ProvideHTTPRequestDurationSeconds(in MetricsIn) *srvhttp.RequestDurationSec
 	http := stdprometheus.NewHistogramVec(stdprometheus.HistogramOpts{
 		Name: "http_request_duration_seconds",
 		Help: "Total time spent serving requests.",
-	}, []string{"module", "service", "route"})
+	}, []string{"module", "service", "route", "status"})
 
 	if in.Registerer == nil {
 		in.Registerer = stdprometheus.DefaultRegisterer
@@ -44,7 +44,7 @@ func ProvideGRPCRequestDurationSeconds(in MetricsIn) *srvgrpc.RequestDurationSec
 	grpc := stdprometheus.NewHistogramVec(stdprometheus.HistogramOpts{
 		Name: "grpc_request_duration_seconds",
 		Help: "Total time spent serving requests.",
-	}, []string{"module", "service", "route"})
+	}, []string{"module", "service", "route", "status"})
 
 	if in.Registerer == nil {
 		in.Registerer = stdprometheus.DefaultRegisterer

--- a/srvgrpc/metrics_test.go
+++ b/srvgrpc/metrics_test.go
@@ -2,9 +2,11 @@ package srvgrpc
 
 import (
 	"context"
-	"github.com/DoNewsCode/core/internal/stub"
 	"testing"
 	"time"
+
+	"github.com/DoNewsCode/core/internal/stub"
+	"google.golang.org/grpc/status"
 
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
@@ -13,11 +15,11 @@ import (
 func TestRequestDurationSeconds(t *testing.T) {
 	histogram := &stub.Histogram{}
 	rds := NewRequestDurationSeconds(histogram)
-	rds = rds.Module("m").Service("s").Route("r")
-	rds.Observe(5)
+	rds = rds.Module("m").Service("s").Status(1).Route("r")
+	rds.Observe(5 * time.Second)
 
 	assert.Equal(t, 5.0, histogram.ObservedValue)
-	assert.ElementsMatch(t, []string{"module", "m", "service", "s", "route", "r"}, histogram.LabelValues)
+	assert.ElementsMatch(t, []string{"module", "m", "service", "s", "route", "r", "status", "1"}, histogram.LabelValues)
 
 	f := grpc.UnaryHandler(func(ctx context.Context, req interface{}) (interface{}, error) {
 		time.Sleep(time.Millisecond)
@@ -25,4 +27,14 @@ func TestRequestDurationSeconds(t *testing.T) {
 	})
 	_, _ = Metrics(rds)(context.Background(), nil, &grpc.UnaryServerInfo{FullMethod: "/"}, f)
 	assert.GreaterOrEqual(t, 1.0, histogram.ObservedValue)
+}
+
+func TestMetrics(t *testing.T) {
+	handler := grpc.UnaryHandler(func(ctx context.Context, req interface{}) (interface{}, error) {
+		return nil, status.Error(2, "error")
+	})
+	histogram := &stub.Histogram{}
+	rds := NewRequestDurationSeconds(histogram)
+	Metrics(rds)(context.Background(), nil, &grpc.UnaryServerInfo{FullMethod: "/"}, handler)
+	assert.Equal(t, "2", histogram.LabelValues.Label("status"))
 }

--- a/srvhttp/metrics_test.go
+++ b/srvhttp/metrics_test.go
@@ -1,11 +1,12 @@
 package srvhttp
 
 import (
-	"github.com/DoNewsCode/core/internal/stub"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/DoNewsCode/core/internal/stub"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -13,11 +14,11 @@ import (
 func TestRequestDurationSeconds(t *testing.T) {
 	histogram := &stub.Histogram{}
 	rds := NewRequestDurationSeconds(histogram)
-	rds = rds.Module("m").Service("s").Route("r")
-	rds.Observe(5)
+	rds = rds.Module("m").Service("s").Route("r").Status(8)
+	rds.Observe(5 * time.Second)
 
 	assert.Equal(t, 5.0, histogram.ObservedValue)
-	assert.ElementsMatch(t, []string{"module", "m", "service", "s", "route", "r"}, histogram.LabelValues)
+	assert.ElementsMatch(t, []string{"module", "m", "service", "s", "route", "r", "status", "8"}, histogram.LabelValues)
 
 	f := http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		time.Sleep(time.Millisecond)
@@ -31,5 +32,5 @@ func TestRequestDurationSeconds_noPanicWhenMissingLabels(t *testing.T) {
 	histogram := &stub.Histogram{}
 	rds := NewRequestDurationSeconds(histogram)
 	rds.Observe(50)
-	assert.ElementsMatch(t, []string{"module", "unknown", "service", "unknown", "route", "unknown"}, histogram.LabelValues)
+	assert.ElementsMatch(t, []string{"module", "unknown", "service", "unknown", "route", "unknown", "status", "0"}, histogram.LabelValues)
 }


### PR DESCRIPTION
BREAKING CHANGE: most Observe() methods now take a time.Duration instead of float64.