### PR TITLE
fix(factory): on reload, close the connection right away.

### DIFF
--- a/cron/options_test.go
+++ b/cron/options_test.go
@@ -179,7 +179,7 @@ func TestJobOption(t *testing.T) {
 			},
 			func(ctx context.Context) error {
 				entryCount++
-				time.Sleep(5 * time.Millisecond)
+				time.Sleep(6 * time.Millisecond)
 				return nil
 			},
 			func(t *testing.T) {

--- a/di/factory.go
+++ b/di/factory.go
@@ -2,8 +2,6 @@ package di
 
 import (
 	"context"
-	"reflect"
-	"runtime"
 	"sync"
 
 	"golang.org/x/sync/singleflight"
@@ -69,17 +67,7 @@ func (f *Factory) SubscribeReloadEventFrom(dispatcher contract.Dispatcher) {
 				if pair.Closer == nil {
 					return true
 				}
-				finalized := make(chan struct{})
-				if reflect.TypeOf(pair.Conn).Kind() == reflect.Ptr {
-					runtime.SetFinalizer(pair.Conn, func(_ interface{}) { finalized <- struct{}{} })
-				}
-				go func() {
-					select {
-					case <-ctx.Done():
-					case <-finalized:
-					}
-					pair.Closer()
-				}()
+				pair.Closer()
 				return true
 			})
 			return nil


### PR DESCRIPTION
graceful shutdown logic should be implemented in the close function, not in the factory.