### PR TITLE
refactor: change leader election semantics.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -63,8 +63,8 @@ jobs:
       minio:
         image: bitnami/minio:latest
         env:
-          MINIO_ACCESS_KEY: minioadmin
-          MINIO_SECRET_KEY: minioadmin
+          MINIO_ROOT_USER: minioadmin
+          MINIO_ROOT_PASSWORD: minioadmin
         ports:
           - 9000:9000
         options: --name minio-server

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.18.0-beta2]
+        go-version: [1.18.x]
     runs-on: ubuntu-latest
     services:
       redis:

--- a/README.md
+++ b/README.md
@@ -227,5 +227,7 @@ Be sure to checkout the documentation section to learn more.
 - [Go Kit](https://github.com/DoNewsCode/core-kit) (if multiple transports)
 - [Kratos v2](https://github.com/go-kratos/kratos)
 
+## Thanks for JetBrains OS licenses
 
+<a href="https://www.jetbrains.com/?from=Donews/core" target="_blank"><img src="https://user-images.githubusercontent.com/1787798/69898077-4f4e3d00-138f-11ea-81f9-96fb7c49da89.png" width="150" align="middle"/></a>
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -194,3 +194,7 @@ type HTTPProvider interface {
 - [Gin](https://github.com/DoNewsCode/core-gin) （如果仅限于 HTTP）
 - [Go Kit](https://github.com/DoNewsCode/core-kit) （如果有多个运输工具）
 - [kratos](https://github.com/go-kratos/kratos) (当前 v2 已经可以使用)
+
+## 感谢 JetBrains 开源证书支持
+
+<a href="https://www.jetbrains.com/?from=Donews/core" target="_blank"><img src="https://user-images.githubusercontent.com/1787798/69898077-4f4e3d00-138f-11ea-81f9-96fb7c49da89.png" width="150" align="middle"/></a>

--- a/cron/cancel.lua
+++ b/cron/cancel.lua
@@ -1,0 +1,13 @@
+local job = KEYS[1]
+local hostname = ARGV[1]
+
+local host = redis.call('GET', job .. ':host')
+if host == nil then
+    return -2
+end
+
+if host ~= hostname then
+    return -1
+end
+return redis.call('DEL', job .. ':host')
+

--- a/cron/commit.lua
+++ b/cron/commit.lua
@@ -1,0 +1,18 @@
+local job = KEYS[1]
+local hostname = ARGV[1]
+local next = ARGV[2]
+local expire = tonumber(ARGV[3])
+
+local host = redis.call('GET', job .. ':host')
+if host == nil then
+    return -2
+end
+
+if host ~= hostname then
+    return -1
+end
+
+redis.call('SET', job .. ':next', next)
+redis.call('EXPIRE', job .. ':next', expire)
+return redis.call('DEL', job .. ':host')
+

--- a/cron/example_test.go
+++ b/cron/example_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"time"
-	
+
 	"github.com/DoNewsCode/core"
 	"github.com/DoNewsCode/core/cron"
 	"github.com/DoNewsCode/core/di"
@@ -27,7 +27,11 @@ func (module *CronModule) ProvideCron(crontab *cron.Cron) {
 }
 
 func Example() {
-	c := core.Default(core.WithInline("log.level", "none"))
+	c := core.Default(
+		core.WithInline("log.level", "none"),
+		core.WithInline("http.disable", "true"),
+		core.WithInline("grpc.disable", "true"),
+	)
 	c.Provide(observability.Providers())
 	c.Provide(
 		di.Deps{func() *cron.Cron {

--- a/cron/options.go
+++ b/cron/options.go
@@ -2,12 +2,17 @@ package cron
 
 import (
 	"context"
+	_ "embed"
 	"errors"
 	"fmt"
+	"math"
+	"os"
 	"runtime/debug"
+	"strings"
 	"time"
 
 	"github.com/DoNewsCode/core/logging"
+	"github.com/go-redis/redis/v8"
 
 	"github.com/go-kit/log"
 	"github.com/opentracing/opentracing-go"
@@ -92,6 +97,93 @@ func WithTracing(tracer opentracing.Tracer) JobOption {
 	}
 }
 
+//go:embed start.lua
+var startLua string
+
+//go:embed commit.lua
+var commitLua string
+
+//go:embed cancel.lua
+var cancelLua string
+
+// PersistenceConfig is the configuration for WithPersistence.
+type PersistenceConfig struct {
+	// How long will the redis lock be held. By default, the lock will be held for a minute.
+	LockTTL time.Duration
+	// Only missed schedules before this duration can be compensated. By default, it is calculated from the gap between each run.
+	MaxRecoverableDuration time.Duration
+	// The prefix of keys in redis. Make sure each project use different keys to avoid collision.
+	KeyPrefix string
+}
+
+// WithPersistence ensures the job will be run at least once by committing
+// successful runs into redis. If one or more schedule is missed, the driver will
+// compensate the missing run(s) in the next schedule. Users should use
+// GetCurrentSchedule method to determine the targeted schedule of the current
+// run, instead of relying on time.Now.
+func WithPersistence(redis redis.UniversalClient, config PersistenceConfig) JobOption {
+	if config.LockTTL == 0 {
+		config.LockTTL = time.Minute
+	}
+	return func(descriptor *JobDescriptor) {
+		innerRun := descriptor.Run
+		descriptor.Run = func(ctx context.Context) error {
+			var (
+				expectedNext       time.Time
+				expectedNextString interface{}
+				err                error
+				current            = GetCurrentSchedule(ctx)
+				next               = GetNextSchedule(ctx)
+			)
+
+			hostname, _ := os.Hostname()
+			expire := calculateNextTTL(config, current, next)
+
+			cancel := func() {
+				redis.Eval(ctx, cancelLua, []string{descriptor.Name}, []string{hostname})
+			}
+
+			for next.Sub(descriptor.next) <= 0 {
+				keys := []string{strings.Join([]string{config.KeyPrefix, descriptor.Name}, ":")}
+				argv := []string{hostname, fmt.Sprintf("%.0f", config.LockTTL.Round(time.Second).Seconds())}
+				expectedNextString, err = redis.Eval(ctx, startLua, keys, argv).Result()
+				if err != nil {
+					cancel()
+					return fmt.Errorf("failed to start job: %w", err)
+				}
+				if expectedNextString == -2 {
+					cancel()
+					return errors.New("job is already running")
+				}
+				if expectedNextString == -1 {
+					expectedNext = current
+				} else {
+					expectedNext, err = time.Parse(time.RFC3339, expectedNextString.(string))
+					if err != nil {
+						cancel()
+						return fmt.Errorf("could not parse expected next time: %s", err)
+					}
+				}
+
+				current = expectedNext
+				next = descriptor.Schedule.Next(current)
+				ctx = context.WithValue(ctx, prevContextKey, current)
+				ctx = context.WithValue(ctx, nextContextKey, next)
+				err = innerRun(ctx)
+				if err != nil {
+					cancel()
+					return err
+				}
+				if err := redis.Eval(ctx, commitLua, keys, []string{hostname, next.Format(time.RFC3339), expire}).Err(); err != nil {
+					cancel()
+					return fmt.Errorf("failed to commit job: %w", err)
+				}
+			}
+			return nil
+		}
+	}
+}
+
 // SkipIfOverlap returns a new JobDescriptor that will skip the job if it overlaps with another job.
 func SkipIfOverlap() JobOption {
 	ch := make(chan struct{}, 1)
@@ -154,4 +246,11 @@ func Recover(logger log.Logger) JobOption {
 			return innerRun(ctx)
 		}
 	}
+}
+
+func calculateNextTTL(config PersistenceConfig, current, next time.Time) string {
+	if config.MaxRecoverableDuration != 0 {
+		return fmt.Sprintf("%0.f", config.MaxRecoverableDuration.Seconds())
+	}
+	return fmt.Sprintf("%0.f", math.Max(3600, 2*float64(next.Sub(current).Seconds())+1))
 }

--- a/cron/options.go
+++ b/cron/options.go
@@ -121,6 +121,8 @@ type PersistenceConfig struct {
 // compensate the missing run(s) in the next schedule. Users should use
 // GetCurrentSchedule method to determine the targeted schedule of the current
 // run, instead of relying on time.Now.
+//
+// As a side effect, the job will only run once in a cluster.
 func WithPersistence(redis redis.UniversalClient, config PersistenceConfig) JobOption {
 	if config.LockTTL == 0 {
 		config.LockTTL = time.Minute

--- a/cron/start.lua
+++ b/cron/start.lua
@@ -1,0 +1,20 @@
+local job = KEYS[1]
+local hostname = ARGV[1]
+local expire = tonumber(ARGV[2])
+
+local host = redis.call('GET', job .. ':host')
+if host ~= false and host ~= hostname then
+    return -2
+end
+
+redis.call('SET', job .. ':host', hostname)
+redis.call('EXPIRE', job .. ':host', expire)
+
+local expectedNext = redis.call('GET', job .. ':next')
+if expectedNext == false then
+    return -1
+end
+
+return expectedNext
+
+

--- a/leader/dependency.go
+++ b/leader/dependency.go
@@ -94,7 +94,6 @@ func (m out) ProvideRunGroup(group *run.Group) {
 		if err != nil {
 			return err
 		}
-		<-ctx.Done()
 		return nil
 	}, func(err error) {
 		_ = m.Election.Resign(ctx)

--- a/leader/dependency_test.go
+++ b/leader/dependency_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"sync/atomic"
 	"testing"
 
 	"github.com/DoNewsCode/core/config"
@@ -32,7 +31,7 @@ func (m *mockMaker) Make(name string) (*clientv3.Client, error) {
 
 type mockDriver struct{}
 
-func (m mockDriver) Campaign(ctx context.Context, status *atomic.Value) error {
+func (m mockDriver) Campaign(ctx context.Context, toLeader func(bool)) error {
 	panic("implement me")
 }
 

--- a/leader/dependency_test.go
+++ b/leader/dependency_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/DoNewsCode/core/config"
@@ -31,7 +32,7 @@ func (m *mockMaker) Make(name string) (*clientv3.Client, error) {
 
 type mockDriver struct{}
 
-func (m mockDriver) Campaign(ctx context.Context) error {
+func (m mockDriver) Campaign(ctx context.Context, status *atomic.Value) error {
 	panic("implement me")
 }
 

--- a/leader/election_test.go
+++ b/leader/election_test.go
@@ -41,12 +41,12 @@ func TestElection(t *testing.T) {
 	e1 = Election{
 		dispatcher: dispatcher,
 		status:     &Status{isLeader: &atomic.Value{}},
-		driver:     leaderetcd.NewEtcdDriver(client, key.New("test")),
+		driver:     leaderetcd.NewEtcdDriver(client, key.New("el_test")),
 	}
 	e2 = Election{
 		dispatcher: dispatcher,
 		status:     &Status{isLeader: &atomic.Value{}},
-		driver:     leaderetcd.NewEtcdDriver(client, key.New("test")),
+		driver:     leaderetcd.NewEtcdDriver(client, key.New("el_test")),
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 

--- a/leader/election_test.go
+++ b/leader/election_test.go
@@ -41,7 +41,8 @@ func TestElection(t *testing.T) {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 
-	e1.Campaign(ctx)
+	go e1.Campaign(ctx)
+	<-time.After(time.Second)
 	assert.Equal(t, e1.status.IsLeader(), true)
 
 	go e2.Campaign(ctx)

--- a/leader/example_cronjob_test.go
+++ b/leader/example_cronjob_test.go
@@ -3,11 +3,12 @@ package leader_test
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/DoNewsCode/core"
 	"github.com/DoNewsCode/core/di"
 	"github.com/DoNewsCode/core/leader"
 	"github.com/DoNewsCode/core/otetcd"
-	"os"
 
 	"github.com/robfig/cron/v3"
 )

--- a/leader/example_cronjob_test.go
+++ b/leader/example_cronjob_test.go
@@ -3,12 +3,11 @@ package leader_test
 import (
 	"context"
 	"fmt"
-	"os"
-
 	"github.com/DoNewsCode/core"
 	"github.com/DoNewsCode/core/di"
 	"github.com/DoNewsCode/core/leader"
 	"github.com/DoNewsCode/core/otetcd"
+	"os"
 
 	"github.com/robfig/cron/v3"
 )

--- a/leader/example_providers_test.go
+++ b/leader/example_providers_test.go
@@ -4,16 +4,19 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"sync/atomic"
 	"time"
 
 	"github.com/DoNewsCode/core"
 	"github.com/DoNewsCode/core/leader"
 )
 
-type AlwaysLeaderDriver struct{}
+type AlwaysLeaderDriver struct {
+}
 
-func (a AlwaysLeaderDriver) Campaign(ctx context.Context, status *atomic.Value) error {
+func (a AlwaysLeaderDriver) Campaign(ctx context.Context, toLeader func(bool)) error {
+	defer toLeader(false)
+	toLeader(true)
+	<-ctx.Done()
 	return nil
 }
 

--- a/leader/example_providers_test.go
+++ b/leader/example_providers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync/atomic"
 	"time"
 
 	"github.com/DoNewsCode/core"
@@ -12,7 +13,7 @@ import (
 
 type AlwaysLeaderDriver struct{}
 
-func (a AlwaysLeaderDriver) Campaign(ctx context.Context) error {
+func (a AlwaysLeaderDriver) Campaign(ctx context.Context, status *atomic.Value) error {
 	return nil
 }
 

--- a/leader/leaderetcd/etcd_test.go
+++ b/leader/leaderetcd/etcd_test.go
@@ -29,8 +29,8 @@ func TestNewEtcdDriver(t *testing.T) {
 	assert.NoError(t, err)
 	defer client.Close()
 
-	e1d := leaderetcd.NewEtcdDriver(client, key.New("test"))
-	e2d := leaderetcd.NewEtcdDriver(client, key.New("test"))
+	e1d := leaderetcd.NewEtcdDriver(client, key.New("etcd_test"))
+	e2d := leaderetcd.NewEtcdDriver(client, key.New("etcd_test"))
 
 	e1 := leader.NewElection(dispatcher, e1d)
 	e2 := leader.NewElection(dispatcher, e2d)

--- a/leader/leaderetcd/etcd_test.go
+++ b/leader/leaderetcd/etcd_test.go
@@ -41,22 +41,22 @@ func TestNewEtcdDriver(t *testing.T) {
 	go e1.Campaign(ctx)
 	assert.Eventually(t, func() bool {
 		return e1.Status().IsLeader()
-	}, time.Second, 10*time.Millisecond, "e1 should be leader")
+	}, 3*time.Second, 10*time.Millisecond, "e1 should be leader")
 
 	go e2.Campaign(ctx)
 
 	assert.Never(t, func() bool {
 		return e2.Status().IsLeader()
-	}, time.Second, 10*time.Millisecond, "e2 should not be leader")
+	}, 3*time.Second, 10*time.Millisecond, "e2 should not be leader")
 
 	e1.Resign(ctx)
 
 	assert.Eventually(t, func() bool {
 		return e2.Status().IsLeader()
-	}, time.Second, 10*time.Millisecond, "e2 should be leader")
+	}, 3*time.Second, 10*time.Millisecond, "e2 should be leader")
 	assert.Never(t, func() bool {
 		return e1.Status().IsLeader()
-	}, time.Second, 10*time.Millisecond, "e1 should not be leader")
+	}, 3*time.Second, 10*time.Millisecond, "e1 should not be leader")
 
 	e2.Resign(ctx)
 	cancel()

--- a/leader/leaderredis/redis.go
+++ b/leader/leaderredis/redis.go
@@ -81,7 +81,9 @@ func (r *RedisDriver) Campaign(ctx context.Context, status *atomic.Value) error 
 			case <-ctx.Done():
 				return ctx.Err()
 			case <-time.After(1 * r.expiration / 4):
-				r.client.Expire(ctx, r.keyer.Key(":", "leader"), r.expiration).Result()
+				if err := r.client.Expire(ctx, r.keyer.Key(":", "leader"), r.expiration).Err(); err != nil {
+					return fmt.Errorf("renewing leader key: %w", err)
+				}
 			}
 		}
 	}

--- a/leader/leaderredis/redis_test.go
+++ b/leader/leaderredis/redis_test.go
@@ -32,7 +32,9 @@ func TestCampaign(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	go driver.Campaign(ctx, status)
+	go driver.Campaign(ctx, func(b bool) {
+		status.Store(b)
+	})
 
 	assert.Eventually(t, func() bool {
 		return status.Load().(bool) == true

--- a/leader/leaderredis/redis_test.go
+++ b/leader/leaderredis/redis_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -26,15 +27,22 @@ func TestCampaign(t *testing.T) {
 		client: client,
 		keyer:  key.New(),
 	}
-	driver.Campaign(context.Background())
+	status := &atomic.Value{}
+	status.Store(false)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 
-	_, err := client.Get(context.Background(), "leader").Result()
-	assert.NoError(t, err)
+	go driver.Campaign(ctx, status)
 
-	driver.Resign(context.Background())
+	assert.Eventually(t, func() bool {
+		return status.Load().(bool) == true
+	}, time.Second, 10*time.Millisecond, "campaign should have started and successfully become leader")
 
-	_, err = client.Get(context.Background(), "leader").Result()
-	assert.Error(t, err)
+	driver.Resign(ctx)
+
+	assert.Eventually(t, func() bool {
+		return status.Load().(bool) == false
+	}, time.Second, 10*time.Millisecond, "leader should have resigned")
 }
 
 func TestNewRedisDriver(t *testing.T) {
@@ -56,19 +64,28 @@ func TestElection(t *testing.T) {
 	e1 = leader.NewElection(dispatcher, driver)
 	e2 = leader.NewElection(dispatcher, driver)
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
-	e1.Campaign(ctx)
-	assert.Equal(t, e1.Status().IsLeader(), true)
+	go e1.Campaign(ctx)
+	assert.Eventually(t, func() bool {
+		return e1.Status().IsLeader()
+	}, time.Second, 10*time.Millisecond, "e1 should be leader")
+
 	go e2.Campaign(ctx)
-	<-time.After(2 * time.Second)
 
-	assert.Equal(t, true, e1.Status().IsLeader())
-	assert.Equal(t, false, e2.Status().IsLeader())
+	assert.Never(t, func() bool {
+		return e2.Status().IsLeader()
+	}, time.Second, 10*time.Millisecond, "e2 should not be leader")
 
 	e1.Resign(ctx)
-	time.Sleep(10 * time.Millisecond)
-	assert.Equal(t, false, e1.Status().IsLeader())
-	assert.Equal(t, true, e2.Status().IsLeader())
+
+	assert.Eventually(t, func() bool {
+		return e2.Status().IsLeader()
+	}, time.Second, 10*time.Millisecond, "e2 should be leader")
+	assert.Never(t, func() bool {
+		return e1.Status().IsLeader()
+	}, time.Second, 10*time.Millisecond, "e1 should not be leader")
+
 	e2.Resign(ctx)
 	cancel()
 }


### PR DESCRIPTION
Now leader election campaign will not return when the node beomes leader, instead it will block until the leader election session exits, updating status proactively. This change will make leader election status more accurate.